### PR TITLE
Add support for Amazon logistics TBA numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ USPS 91                               | 25-34 | `420 221539101026837331000039521
 OnTrac                                | 15    | `C11031500001879`                                                                          | `SerialNumber` `CheckDigit`
 DHL Express                           | 10    | `3318810025`                                                                               | `SerialNumber` `CheckDigit`
 DHL Express Air                       | 10    | `73891051146`                                                                              | `SerialNumber` `CheckDigit`
-
+Amazon Logistics                      | 15    | `TBA 487064622 000`                                                                        | `SerialNumber`
 
 ## JSON Format
 
@@ -47,6 +47,22 @@ DHL Express Air                       | 10    | `73891051146`                   
     - `validation` - Specifies how the tracking number is validated
       - `checksum`
         - `name`: specifies the algorithm. Supported algorithms and parameters are `mod10`, `mod7`, `s10`, and `sum_product_with_weightings_and_modulo`. Look at existing examples for parameters.
+        ```JSON
+        "validation": {
+            "checksum": {
+              "name": "mod10",
+              "evens_multiplier": 1,
+              "odds_multiplier": 2
+            }
+          }
+        ```
+
+        - for tracking numbers without checksums, specify checksum: false
+        ```JSON
+        "validation": {
+            "checksum": false
+          }
+        ```
       - `serial_number_format`: some tracking numbers require some modification of the <SerialNumber> group before validation. In the example below, the serial number needs a "91" prepended before validation unless the number starts with a 91, 92, 93, 94, or 95
       ```json
       "serial_number_format": {

--- a/couriers/amazon.json
+++ b/couriers/amazon.json
@@ -8,9 +8,7 @@
         "\\s*T\\s*B\\s*A\\s*(?<SerialNumber>([0-9]\\s*){12,12})\\s*"
       ],
       "validation": {
-        "checksum": {
-          "name": "dummy"
-        }
+        "checksum": false
       },
       "test_numbers": {
         "valid": [

--- a/couriers/amazon.json
+++ b/couriers/amazon.json
@@ -1,0 +1,32 @@
+{
+  "name": "Amazon",
+  "courier_code": "amazon",
+  "tracking_numbers": [
+    {
+      "name": "Amazon Logistics",
+      "regex": [
+        "\\s*T\\s*B\\s*A\\s*(?<SerialNumber>([0-9]\\s*){11,11})",
+        "(?<CheckDigit>([0-9]\\s*))"
+      ],
+      "validation": {
+        "checksum": {
+          "name": "dummy"
+        }
+      },
+      "test_numbers": {
+        "valid": [
+          "TBA000000000000",
+          "TBA010000000000",
+          " T B A 0 0 0 0 0 0 0 0 0 0 0 0 ",
+          "TBA502887274000"
+        ],
+        "invalid": [
+          "TBA50288727400A",
+          "000000000000000",
+          "000000000000",
+          "TBB000000000000"
+        ]
+      }
+    }
+  ]
+}

--- a/couriers/amazon.json
+++ b/couriers/amazon.json
@@ -5,8 +5,7 @@
     {
       "name": "Amazon Logistics",
       "regex": [
-        "\\s*T\\s*B\\s*A\\s*(?<SerialNumber>([0-9]\\s*){11,11})",
-        "(?<CheckDigit>([0-9]\\s*))"
+        "\\s*T\\s*B\\s*A\\s*(?<SerialNumber>([0-9]\\s*){12,12})\\s*"
       ],
       "validation": {
         "checksum": {


### PR DESCRIPTION
I looked at a dataset of about 500 TBA tracking numbers, sorted by delivery datetime.

-  The general format for the number is:  TBA 487064622 000
- Over the last few months, I see the numbers generally increasing, which makes me suspect that these numbers represent an atomically increasing counter (perhaps skipping values here and there).  I have not seen a single TBA number where the last 3 digits are non-zero.  

---

As a side note, if it is a counter, I wonder if these TBA numbers serve as a general gauge for how many Amazon packages ship via Amazon Logistics?  I bet business competitors would be interested in tracking the number of packages shipped each month, and it looks like all they'd need to do is order something on Amazon once a month and then difference the numbers.  :)