### PR TITLE
closes issue #5, variation of USPS 34 digit barcodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ algorithms for various couriers.
   > 20 charss { "fedexsscc-18": "regex": "\d{2}(?<container_type>\d)(?<shipper_id>\d{7})(?<serial>\d{9})(?<check>\d)"}
         "UCC/EAN 128": "regex": ""
 - usps:
+  - https://ribbs.usps.gov/intelligentmail_package/documents/tech_guides/PUB199IMPBImpGuide.pdf
+    - page 109
   - http://about.usps.com/publications/pub97.pdf
     - "Electronic File Number"
     - "Package Identification Code (PIC)"

--- a/couriers/usps.json
+++ b/couriers/usps.json
@@ -57,7 +57,40 @@
       ]
     },
     {
+      "name": "USPS 34v2",
+      "description": "variation on 34 digit USPS IMpd numbers",
+      "regex": [
+        "\\s*(?<RoutingApplicationId>4\\s*2\\s*0\\s*)(?<DestinationZip>([0-9]\\s*){5})",
+        "(?<RoutingNumber>([0-9]\\s*){4})",
+        "(?<SerialNumber>",
+        "(?<ApplicationIdentifier>9\\s*[2345]\\s*)?",
+        "(?<ShipperId>([0-9]\\s*){8})",
+        "(?<PackageId>([0-9]\\s*){11})",
+        ")",
+        "(?<CheckDigit>[0-9]\\s*)"
+      ],
+      "validation": {
+        "checksum": {
+          "name": "mod10",
+          "evens_multiplier": 3,
+          "odds_multiplier": 1
+        }
+      },
+      "tracking_url": "https://m.usps.com/m/TrackConfirmAction_detail?tLabels=%s",
+      "test_numbers": {
+        "valid": [
+          "4201002334249200190132607600833457",
+          "4201028200009261290113185417468510",
+          " 4 2 0 1 0 2 8 2 0 0 0 0 9 2 6 1 2 9 0 1 1 3 1 8 5 4 1 7 4 6 8 5 1 0 "
+        ],
+        "invalid": [
+          "4201028200009261290113185417468511"
+        ]
+      }
+    },
+    {
       "name": "USPS 91",
+      "description": "USPS now calls this the IMpd barcode format",
       "regex": [
         "\\s*(?:(?<RoutingApplicationId>4\\s*2\\s*0\\s*)(?<DestinationZip>([0-9]\\s*){5}))?",
         "(?<SerialNumber>",


### PR DESCRIPTION
Supports an (I think undocumented) variation of USPS 34 digit
IMpd tracking numbers found in a dataset of tracking numbers.  dataset has images of package
labels and barcodes that prove these numbers do exist.

Adds another link to more recent documentation that may be helpful in future.

