### PR TITLE
Add lots of tests to validate formatting and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Amazon Logistics                      | 15    | `TBA 487064622 000`             
               }
             ]
           }
-        ]```
+        ]
+    ```
 
     Each hash in the `lookup` array should contain a key called `matches` or `matces_regex`, specifying how the value of `regex_group_name` should be compared.
 

--- a/couriers/amazon.json
+++ b/couriers/amazon.json
@@ -8,7 +8,6 @@
         "\\s*T\\s*B\\s*A\\s*(?<SerialNumber>([0-9]\\s*){12,12})\\s*"
       ],
       "validation": {
-        "checksum": false
       },
       "test_numbers": {
         "valid": [

--- a/couriers/lasership.json
+++ b/couriers/lasership.json
@@ -5,17 +5,19 @@
     {
       "name": "LaserShip LX",
       "regex": [
-        "\\s*L\\s*X\\s*1\\s*[3-8]\\s*(?<SerialNumber>([0-9]\\s*){6,6})"
+        "\\s*L\\s*X\\s*1\\s*[3-8]\\s*(?<SerialNumber>([0-9]\\s*){6,6})\\s*"
       ],
       "validation": {
       },
       "test_numbers": {
         "valid": [
-          "LX17635036"
+          "LX17635036",
+          "LX 176 35035",
+          "LX17635034"
         ],
         "invalid": [
-          "LX17635036N",
-          "LX176350N6",
+          "LX1763503N",
+          "LC176350N6",
           "LA17635036",
           " L A 1 7 6 3 5 0 3 6 "
         ]
@@ -25,7 +27,7 @@
       "name": "LaserShip 1LS7 (15)",
       "regex": [
         "\\s*1\\s*L\\s*S\\s*7\\s*[12]\\s*([0-9]\\s*){4,4}",
-        "(?<SerialNumber>([0-9]\\s*){6,6})"
+        "(?<SerialNumber>([0-9]\\s*){6,6})\\s*"
       ],
       "validation": {
       },
@@ -37,7 +39,7 @@
           " 1 L S 7 2 0 0 0 0 0 0 0 0 0 0 "
         ],
         "invalid": [
-          "1LS734505321754"
+          "1LX734505321754"
         ]
       }
     },

--- a/couriers/s10.json
+++ b/couriers/s10.json
@@ -140,14 +140,6 @@
               "upu_reference_url": "http://www.upu.int/en/the-upu/member-countries/eastern-europe-and-northern-asia/armenia.html"
             },
             {
-              "country": "Aruba, Curaçao and Sint Maarten",
-              "matches": null,
-              "courier": "Post Aruba N.V",
-              "courier_url": "http://www.postaruba.com/",
-              "upu_reference_url": "http://www.upu.int/en/the-upu/member-countries/americas/aruba-curacao-and-sint-maarten.html",
-              "regex": null
-            },
-            {
               "matches": "AU",
               "country": "Australia",
               "courier": "Australia Post",

--- a/couriers/usps.json
+++ b/couriers/usps.json
@@ -9,7 +9,7 @@
       "regex": [
         "\\s*(?<SerialNumber>",
         "(?<ServiceType>([0-9]\\s*){2})",
-        "(?<MailerId>([0-9]\\s*){9})",
+        "(?<ShipperId>([0-9]\\s*){9})",
         "(?<PackageId>([0-9]\\s*){8})",
         ")",
         "(?<CheckDigit>[0-9]\\s*)"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,112 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => true)]
+Minitest::Reporters.use!(
+Minitest::Reporters::SpecReporter.new,
+ENV,
+Minitest.backtrace_filter
+)
 
 class Minitest::Test
 
+  def validate_with_checksum(tracking_number, info)
+    pattern = [info[:regex]].flatten.join("")
+    regex = Regexp.new(pattern)
+
+    match = regex.match(tracking_number)
+
+    raw_serial_number = match["SerialNumber"].gsub(/\s/, '')
+    check_digit = match["CheckDigit"].gsub(/\s/, '')
+    checksum_info = info[:validation][:checksum]
+
+    serial_number = format_serial_number(raw_serial_number, info[:validation][:serial_number_format])
+
+    result = self.send("validates_#{checksum_info[:name]}?", serial_number, check_digit, checksum_info)
+
+    if block_given?
+      yield result, checksum_info[:name], serial_number, check_digit
+    else
+      result
+    end
+  end
+
+  def assert_valid_checksum(tracking_number, info)
+    validate_with_checksum(tracking_number, info) do |result, name, serial_number, check_digit|
+      assert result, "#{tracking_number} should have matched #{name} checksum algorithm with serial number = #{serial_number} and check digit = #{check_digit}"
+    end
+  end
+
+  protected
+
+  def format_serial_number(raw_serial, format_info)
+    if format_info
+      if format_info[:prepend_if] && raw_serial.match(Regexp.new(format_info[:prepend_if][:matches_regex]))
+        return "#{format_info[:prepend_if][:content]}#{raw_serial}"
+      elsif format_info[:prepend_if_missing]
+
+      end
+    end
+
+    return raw_serial
+  end
+
+  def validates_s10?(sequence, check_digit, extras = {})
+    weighting = [8,6,4,2,3,5,9,7]
+
+    total = 0
+    sequence.chars.to_a.zip(weighting).each do |(a,b)|
+      total += a.to_i * b.to_i
+    end
+
+    remainder = total % 11
+    check = case remainder
+    when 1
+      0
+    when 0
+      5
+    else
+      11 - remainder
+    end
+
+    return check.to_i == check_digit.to_i
+  end
+
+  def validates_sum_product_with_weightings_and_modulo?(sequence, check_digit, extras = {})
+    weighting = extras[:weightings] || []
+
+    total = 0
+    sequence.chars.to_a.zip(weighting).each do |(a,b)|
+      total += a.to_i * b
+    end
+    return (total % extras[:modulo1] % extras[:modulo2]) == check_digit.to_i
+  end
+
+  def validates_mod10?(sequence, check_digit, extras = {})
+    total = 0
+    sequence.chars.each_with_index do |c, i|
+      x = if c[/[0-9]/] # numeric
+        c.to_i
+      else
+        (c[0].ord - 3) % 10
+      end
+
+      if extras[:odds_multiplier] && i.odd?
+        x *= extras[:odds_multiplier].to_i
+      elsif extras[:evens_multiplier] && i.even?
+        x *= extras[:evens_multiplier].to_i
+      end
+
+      total += x
+    end
+
+    check = (total % 10)
+    check = (10 - check) unless (check.zero?)
+
+    return (check.to_i == check_digit.to_i)
+  end
+
+  def validates_mod7?(sequence, check_digit, extras = {})
+    # standard mod 7 check
+    return true if sequence.to_i % 7 == check_digit.to_i
+  end
 end

--- a/test/tracking_number_data_test.rb
+++ b/test/tracking_number_data_test.rb
@@ -3,18 +3,167 @@ require 'active_support'
 require 'json'
 require 'active_support/core_ext/hash'
 require 'active_support/core_ext/string'
-require 'shoulda'
 
 def courier_files
   Dir.glob(File.join(File.dirname(__FILE__), "../couriers/*.json"))
 end
 
+def parsed_json_file(file)
+  JSON.parse(File.read(file)).deep_symbolize_keys!
+end
+
 class TrackingNumberDataTest < Minitest::Test
+  extend Minitest::Spec::DSL
+
   courier_files.each do |file|
     file_name = file.split('/').last
-    should "read #{file_name} as valid and parseable json" do
-      json = JSON.parse(File.read(file)).deep_symbolize_keys!
-      assert json
+    describe file_name do
+      subject { file }
+
+      it "has a file name without spaces" do
+        assert_match /[a-z0-9]/, file_name
+      end
+
+      it "should read as valid and parseable json" do
+        assert parsed_json_file(file)
+      end
+
+      describe "courier details" do
+        subject { parsed_json_file(file) }
+
+        it "should have a human readable name" do
+          refute_match /\_/, subject[:name], "should not have underscores"
+        end
+
+        it "should have a valid courier_code" do
+          refute_match /\s/, subject[:courier_code], "should not have spaces"
+          assert_match /^([a-z])([a-z][0-9])*/, subject[:courier_code], "should start with a lowercase letter and only contain lowercase letters and numbers"
+          assert subject[:courier_code].size > 0, "courier code should not be empty"
+        end
+      end
+
+      parsed_json_file(file)[:tracking_numbers].each do |info|
+        describe info[:name] do
+          subject { info }
+
+          let(:pattern) { [subject[:regex]].flatten.join("") }
+
+          it "includes a validation block, even if empty" do
+            assert subject.keys.include?(:validation)
+          end
+
+          it "includes a regex key as a string or an array of strings" do
+            assert subject[:regex]
+            assert subject[:regex].is_a?(String) || subject[:regex].is_a?(Array), "Regex must either be a string, or an array of strings"
+            if subject[:regex].is_a?(Array)
+              assert subject[:regex].all? { |r| r.is_a? String }
+            end
+          end
+
+          it "has a pattern that compiles as regex" do
+            assert Regexp.new(pattern)
+          end
+
+          it "has a pattern that can match spaces are double backslashed" do
+            assert_match /\\s\*/, pattern
+          end
+
+          it "includes a <SerialNumber> character group" do
+            assert pattern.include?("?<SerialNumber>")
+          end
+
+          it "if it includes a <CheckDigit> group, then validation is specified" do
+            if pattern.include?("?<CheckDigit>")
+              assert info[:validation][:checksum][:name]
+            end
+          end
+
+          it "only includes character groups with agreed upon keys" do
+            regex = Regexp.new(pattern)
+
+            valid_keys = ["SerialNumber", "CheckDigit", "ServiceType", "CountryCode", "DestinationZip", "PackageId", "ShipperId", "SSID", "ShippingContainerType", "ApplicationIdentifier", "RoutingApplicationId", "SCNC", "GSN", "RoutingNumber"]
+
+            regex.names.each do |name|
+              assert valid_keys.include?(name), "#{name} is not recognized as a known character group. Try to use as few keys as possible globally"
+            end
+          end
+
+          it "if checksum is provided, it is never empty" do
+            assert (subject[:validation][:checksum].nil? || subject[:validation][:checksum][:name])
+          end
+
+          it "includes valid test numbers" do
+            uniques = subject[:test_numbers][:valid].uniq.size
+            assert uniques > 1, "must include more unique valid test numbers, only found #{uniques}"
+          end
+
+          it "includes invalid test numbers" do
+            uniques = subject[:test_numbers][:invalid].uniq.size
+            assert uniques > 0, "must include invalid test numbers, found none"
+          end
+
+          it "matches included valid numbers with pattern" do
+            regex = Regexp.new(pattern)
+
+            subject[:test_numbers][:valid].each do |valid|
+              assert regex.match(valid), "#{valid} did not match provided pattern"
+            end
+          end
+
+          it "matches included valid numbers with specified checksum algorithm" do
+            regex = Regexp.new(pattern)
+
+            subject[:test_numbers][:valid].each do |valid|
+              if checksum_info = subject[:validation][:checksum]
+                assert_valid_checksum(valid, info)
+              end
+            end
+          end
+
+          it "does not validate invalid numbers" do
+            regex = Regexp.new(pattern)
+
+            subject[:test_numbers][:invalid].each do |invalid|
+              passes_pattern_test = regex.match(invalid)
+              has_checksum         = subject[:validation][:checksum]
+              has_additional_check = info[:validation][:additional]
+              #TODO: implement an actual additional check
+
+              results = []
+              results << passes_pattern_test
+              results << validate_with_checksum(invalid, info) if has_checksum && passes_pattern_test
+              results << false if has_additional_check
+
+              assert(!results.all? {|r| r }, "#{invalid} should not have passed validation checks")
+            end
+          end
+
+          it "should include valid additional section" do
+            if info.keys.include?(:additional)
+              assert info[:additional].is_a?(Array), "Additional should be an array"
+            end
+          end
+
+          it "should have an included regex group in each additional section" do
+            if info.keys.include?(:additional)
+              info[:additional].each do |section|
+                regex = Regexp.new(pattern)
+                assert regex.names.include?(section[:regex_group_name]), "'#{section[:regex_group_name]}' not found in match groups #{regex.names}"
+              end
+            end
+          end
+
+          it "should have `matches` or `matches_regex` key in each lookup value" do
+            if info.keys.include?(:additional)
+              info[:additional].each do |section|
+                section[:lookup].each do |lookup|
+                    assert (lookup[:matches] || lookup[:matches_regex]), "could not find `matches` or `matches_regex` within #{lookup}"
+                end
+              end
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Added tests to check formatting and agreed upon file requirements. It also does some validation checks on the test numbers provided, and some checks to make sure we're providing good test numbers.

Also writing these tests brought to light a couple of small bugs that I resolved too.

1. We were using ShipperId in most tracking number group names, but one had MailerId. There's a test to make sure we keep that list of variables small.

2. There was an lookup value in the s10.json file without a `match` value, which we said was required. So I just removed it. Sorry Aruba for now.