### PR TITLE
Model partnerships between shipping couriers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,7 @@ This repository contains json files that programatically describe how to detect,
             }
           }
         ```
-    - `tracking_url` - A url that we can use to find the tracking
-      history for a particular tracking number. It assumes the
-      tracking number can be entered using python style
-      string formatting "www.courier.com?trackingnumber=%s".
+    - `tracking_url` - A url that we can use to find the tracking history for a particular tracking number. It assumes the tracking number can be entered using python style string formatting "www.courier.com?trackingnumber=%s".
 
     - `test_numbers`:
       - `valid`: an array of valid tracking numbers for testing
@@ -107,6 +104,35 @@ This repository contains json files that programatically describe how to detect,
 
     Each hash in the `lookup` array should contain a key called `matches` or `matces_regex`, specifying how the value of `regex_group_name` should be compared.
 
+
+    - `partners` - Each entry of the partners array describes a possible partnership between carriers. A partnership is only valid if both ends of the partnership pass the checks. If the tracking number passes both sets of validation, this indicates that the shipment was handled by both parties, usually one acting as the _shipper_, and the other as the last mile _carrier_. Each item in the partners array should have:    
+      -  `partner_id`: (required) reference indicating the related definition
+      -  `partner_type`: (required) indicating the type of relationship. Currently the two supported relationship types are `shipper` and `carrier`. 
+      -  `description`: (optional) mainly for humans reading this
+      -  `validation`: (optional) a validation block that determins if this partnership applies
+        -  `matches_all` or `matches_any`: array of match conditions. Each match condition must have a `regex_group_name` indicating the name of the regex group to match against, and then either a `matches` key or a `matches_regex` key with a string or a regex to match against
+
+        ```json
+            //usps.json
+      
+            "partners": [{
+              "partner_id": "fedex_smartpost",
+              "partner_type": "origin",
+              "description": "FedEx SmartPost uses USPS for last mile delivery, but not all USPS91 numbers are SmartPosts",
+              "validation": {
+                "matches_all": [
+                   {
+                     "regex_group_name": "ServiceType",
+                     "matches": "29"
+                   },
+                   {
+                     "regex_group_name": "SCNC",
+                     "matches": "62"
+                   }
+                ]
+              }
+            }],
+        ```
 
 
 ### Making a contribution

--- a/couriers/fedex.json
+++ b/couriers/fedex.json
@@ -90,20 +90,38 @@
     },
     {
       "name": "FedEx SmartPost",
-      "description": "IMpb CO3 standard",
       "id": "fedex_smartpost",
+      "description": "Shipped by FedEx, Delivered by USPS",
       "regex": [
         "\\s*(?:",
         "(?:(?<RoutingApplicationId>4\\s*2\\s*0\\s*)(?<DestinationZip>([0-9]\\s*){5}))?",
         "(?<ApplicationIdentifier>9\\s*2\\s*)",
         ")?",
         "(?<SerialNumber>",
-        "(?<ServiceType>([0-9]\\s*){3})",
-        "(?<ShipperId>([0-9]\\s*){9})",
-        "(?<PackageId>([0-9]\\s*){7})",
+        "(?<SCNC>([0-9]\\s*){2})",
+        "(?<ServiceType>([0-9]\\s*){2})",
+        "(?<ShipperId>([0-9]\\s*){8})",
+        "(?<PackageId>([0-9]\\s*){11}|([0-9]\\s*){7})",
         ")",
         "(?<CheckDigit>([0-9]\\s*))"
       ],
+      "additional": [
+        {
+          "name": "Service Type",
+          "regex_group_name": "ServiceType",
+          "lookup": [
+            {
+              "matches_regex": ".",
+              "name": "Delivered by USPS"
+            }
+          ]
+        }
+      ],
+      "partners": [{
+        "partner_id": "usps_91",
+        "partner_type": "carrier",
+        "description": "FedEx SmartPost is a shipping service that utilizes FedEx for the initial transport and the United States Postal Service for final delivery."
+      }],
       "validation": {
         "checksum": {
           "name": "mod10",
@@ -121,7 +139,6 @@
       "test_numbers": {
         "valid": [
           "61299998820821171811",
-          " 6 1 2 9 9 9 9 8 8 2 0 8 2 1 1 7 1 8 1 1 ",
           "9261292700768711948021",
           "420 11213 92 6129098349792366623 8",
           "92 6129098349792366623 8",

--- a/couriers/usps.json
+++ b/couriers/usps.json
@@ -118,6 +118,23 @@
           }
         }
       },
+      "partners": [{
+        "description": "FedEx SmartPost uses USPS for last mile delivery, but not all USPS91 numbers are SmartPosts",
+        "partner_type": "shipper",
+        "partner_id": "fedex_smartpost",
+        "validation": {
+          "matches_all": [
+            {
+              "regex_group_name": "ServiceType",
+              "matches": "29"
+            },
+            {
+              "matches": "61",
+              "regex_group_name": "SCNC"
+            }
+          ]
+        }
+      }],
       "tracking_url": "https://tools.usps.com/go/TrackConfirmAction?tLabels=%s",
       "test_numbers": {
         "valid": [
@@ -136,7 +153,23 @@
           "420000000000000000000000000000",
           "420000009200000000000000000000"
         ]
-      }
+      },
+      "additional": [
+        {
+          "name": "Service Type",
+          "regex_group_name": "ServiceType",
+          "lookup": [
+            {
+              "matches": "11",
+              "name": "First Class (R)"
+            },
+            {
+              "matches": "29",
+              "name": "Fedex Smart Post"
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Certain shipments (e.g. FedEx SmartPost) are shared between carriers, and until this PR this dataset had no way of modeling that relationship. Previously, consuming libraries would successfully match a FedExSmartPost number like `420112139261290983497923666238` against the `FedExSmartPost` criteria, and the `USPS91` criteria and return both to the consumer. This wasn't _wrong_, but it wasn't the complete answer either. #12, #23

This change now models both sides of the relationship so that consuming libraries can detect if the tracking number returned is a partnership, and which part of the relationship that tracking number fulfills. One side of the partnership is a `shipper` (e.g FedEx), and the other side is the [last mile] `carrier` (e.g. USPS). 

This is how it's implemented in the upcoming version of `tracking_number`

```ruby
# Search defaults to only showing numbers that fulfill the carrier side of the relationship 
# (if a partnership exists at all), as this is the end a consumer would most likely be interested in.

results = TrackingNumber.search('420112139261290983497923666238') 
=> [#<TrackingNumber::USPS91:0x26ac0 420112139261290983497923666238>]

tn = results.first
tn.shipper? #=> false
tn.carrier? #=> true
tn.partnership? #=> true
tn.partners
 #=> <struct TrackingNumber::Base::PartnerStruct
 #       shipper=#<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>,
 #       carrier=#<TrackingNumber::USPS91:0x2f1fc 420112139261290983497923666238>>

tn.partners.shipper #=> #<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>
tn.partners.carrier == tn #=> true
```

To return both the shipper and carrier when searching, you can pass a second argument into search:
```ruby 
results = TrackingNumber.search('420112139261290983497923666238', match: :all) 
#=> [<TrackingNumber::FedExSmartPost:0x30624 420112139261290983497923666238>, <TrackingNumber::USPS91:0x2f1fc 420112139261290983497923666238>]

```

TrackingNumbers that are not a partnership fulfill both sides of the relationship and indicate as such: 
```ruby
tn = TrackingNumber.new('1Z879E930346834440')

tn.shipper? #=> true
tn.carrier? #=> true
tn.partnership? #=> false
tn.partners #=> nil

```
