### PR TITLE
add golang embed

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,6 @@
+package tracking
+
+import "embed"
+
+//go:embed couriers/*
+var Couriers embed.FS

--- a/embed_test.go
+++ b/embed_test.go
@@ -1,0 +1,44 @@
+package tracking_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	tracking "github.com/jkeen/tracking_number_data"
+)
+
+func TestEmbed(t *testing.T) {
+	dir, err := os.ReadDir("couriers")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files := make([]string, 0, len(dir))
+	for _, f := range dir {
+		name := f.Name()
+		if len(name) > 5 && name[len(name)-5:] == ".json" {
+			files = append(files, name)
+		}
+	}
+
+	if len(files) == 0 {
+		t.Fatal("no files found")
+	}
+
+	for _, f := range files {
+		embedBytes, err := tracking.Couriers.ReadFile(fmt.Sprintf("couriers/%s", f))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fsBytes, err := os.ReadFile(fmt.Sprintf("couriers/%s", f))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(embedBytes) != string(fsBytes) {
+			t.Fatalf("%s: embedded file does not match filesystem file", f)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jkeen/tracking_number_data
 
-go 1.20
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jkeen/tracking_number_data
+
+go 1.20


### PR DESCRIPTION
This PR allows the courier data to be installed with `go get` and embedded in golang applications.