### PR TITLE
Correct serial number group for DHL express numbers

### DIFF
--- a/couriers/dhl.json
+++ b/couriers/dhl.json
@@ -5,7 +5,7 @@
     {
       "name": "DHL Express",
       "id": "dhl_express",
-      "regex": "\\s*(?<SerialNumber>(J[A-Z][A-Z][A-Z])?([0-9])?([0-9]\\s*){9})(?<CheckDigit>([0-9]\\s*))",
+      "regex": "\\s*(?<SerialNumber>([0-9]\\s*){9,10})(?<CheckDigit>([0-9]\\s*))",
       "validation": {
         "checksum": {
           "name": "mod7"
@@ -14,18 +14,34 @@
       "tracking_url": "http://www.dhl.com/en/express/tracking.html?brand=DHL&AWB=%s",
       "test_numbers": {
         "valid": [
-          "JVGL0999999990",
           "3318810025",
           "73891051146",
           "8487135506",
+          "1099255990",
+          "3821724944",
           "3318810036",
           "3318810014"
         ],
         "invalid": [
           "3318810010",
           "3318810034",
-          "JVGL3099999999",
           "3318810011"
+        ]
+      }
+    },
+    {
+      "name": "DHL Express (Piece ID)",
+      "id": "dhl_express_piece_id",
+      "regex": "\\s*(J[A-Z]{2,3})(?<SerialNumber>([0-9]\\s*){9,10})",
+      "validation": {},
+      "tracking_url": "http://www.dhl.com/en/express/tracking.html?brand=DHL&AWB=%s",
+      "test_numbers": {
+        "valid": [
+          "JJD0099999999",
+          "JVGL0999999990"
+        ],
+        "invalid": [
+          "XJD0099999998"
         ]
       }
     },


### PR DESCRIPTION
In working through some of the information from #99 it appears there was an error in the DHL tracking number regex.

For checksum calculations to work, the `<SerialNumber>` group should contain only numbers, but For DHL Express numbers that contained letters as well. The ruby client didn't error due to this since in ruby `"JD000000".to_i == 0`, but in other clients this caused an issue.

This PR corrects that.

Additionally, it turns out with that correction that "JVGL0999999990" does _not_ pass mod7 validation, so I have split those oddball J* dhl numbers into their own group without validation until more information is found about them.