### PR TITLE
Update Amazon Logistics for Mexico/Canada tracking numbers

### DIFF
--- a/couriers/amazon.json
+++ b/couriers/amazon.json
@@ -6,15 +6,15 @@
       "name": "Amazon Logistics",
       "id": "amazon_logistics",
       "regex": [
-        "\\s*T\\s*B\\s*A\\s*(?<SerialNumber>([0-9]\\s*){12,12})\\s*"
+        "\\s*T\\s*B\\s*[ACM]\\s*(?<SerialNumber>([0-9]\\s*){12,12})\\s*"
       ],
       "validation": {},
       "test_numbers": {
         "valid": [
           "TBA000000000000",
           "TBA010000000000",
-          "TBA 000000000000",
-          "TBA502887274000"
+          "TBC 000000000000",
+          "TBM502887274000"
         ],
         "invalid": [
           "TBA50288727400A",


### PR DESCRIPTION
This PR slightly updates the "Amazon Logistics" regex to support tracking numbers intended for Canadian and Mexican destinations. The current regex requires numbers to begin with `TBA`; however, valid tracking numbers may also begin with `TBC` or `TBM`.

Per https://parcelsapp.com/en/carriers/amazon-logistics:

> Packages shipped in US, Canada, Mexico usually get assigned Amazon Logistics tracking numbers starting with TBA, TBM, TBC. For example TBA619632698000, TBC038034537009, TBAONT500361196.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded Amazon Logistics tracking number support to accept additional prefixes for enhanced tracking capability.
  - Updated sample tracking values to align with the improved tracking format validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->