### PR TITLE
allow letters in DHL E-Commerce tracking numbers

### DIFF
--- a/couriers/dhl.json
+++ b/couriers/dhl.json
@@ -48,14 +48,15 @@
     {
       "name": "DHL E-Commerce",
       "id": "dhl_ecommerce",
-      "regex": "\\s*((GM)|(LX)|(RX)|(UV)|(CN)|(SG)|(TH)|(IN)|(HK)|(MY))\\s*(?<SerialNumber>([0-9]\\s*){10,39})",
+      "regex": "\\s*((GM)|(LX)|(RX)|(UV)|(CN)|(SG)|(TH)|(IN)|(HK)|(MY))\\s*(?<SerialNumber>([0-9A-Z]\\s*){10,39})",
       "validation": {},
       "tracking_url": "http://www.dhl.com/en/express/tracking.html?brand=DHL&AWB=%s",
       "test_numbers": {
         "valid": [
           "GM2951173225174494",
           "GM 2 9 5 117 32 25 1 7 44 9 4",
-          "GM295117494011169042"
+          "GM295117494011169042",
+          "GM9E44608A27984866BA2D"
         ],
         "invalid": [
           "GS295117494011169041",


### PR DESCRIPTION
DHL E-Commerce numbers aren't just numbers, but sometimes include letters as well. This patch allows them just by updating the regex and adding a single verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of DHL E-Commerce tracking numbers that include both letters and numbers.

- **Tests**
  - Added new test cases for DHL E-Commerce tracking numbers containing letters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->