### PR TITLE
Add support for the LaserShip 1LSCX format.

### DIFF
--- a/couriers/lasership.json
+++ b/couriers/lasership.json
@@ -79,6 +79,27 @@
           "1LS7119013618127-2"
         ]
       }
+    },
+    {
+      "name": "LaserShip 1LSCX (15)",
+      "id": "lasership_1lscx",
+      "regex": [
+        "\\s*1\\s*L\\s*S\\s*",
+        "\\s*C\\s*X\\s*",
+        "(?<SerialNumber>",
+        "([0-9A-Z]\\s*){10}",
+        ")"
+      ],
+      "validation": {},
+      "test_numbers": {
+        "valid": [
+          "1LS CX VE00 58631Y",
+          "1LSCXVE005BUEFX"
+        ],
+        "invalid": [
+          "1LSCZVE0058631Y"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
I've found examples of this in the wild since 2019. I tried to research the exact format, and determine what the checksum is without success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for LaserShip "1LSCX" tracking numbers so users can enter and track 1LSCX-format IDs.
  * Broader LaserShip format coverage improves automatic detection of additional shipments.

* **Tests**
  * Added validation examples to ensure common valid and invalid 1LSCX inputs are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->