### PR TITLE
feat: Added support for YunExpress tracking numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ This repository contains json files that programatically describe how to detect,
 | **UPS**          | UPS                       | 18     | `1Z5R89390357567127`                                      | `SerialNumber` `CheckDigit` `ShipperId` `ServiceType` `PackageId`                                                         |
 |                  | UPS Waybill               | 11     | `K2479825491` `V0490119172`                               | `ServiceType` `SerialNumber` `CheckDigit`                                                                                 |
 | **USPS**         | USPS 20                   | 20     | `0307 1790 0005 2348 3741`                                | `ServiceType` `ShipperId` `PackageId` `CheckDigit`                                                                        |
+| **YunExpress**   | YunExpress                | 18     | `YT2229521272164446`                                      | `SerialNumber`                                                                                                            |
 |                  | USPS 22                   | 22–27  | `9400111206206406260787` `420787459400111206206406260787` | `RoutingApplicationId` `DestinationZip` `ServiceType` `ShipperId` `PackageId` `CheckDigit`                                |
 |                  | USPS 34v2                 | 34     | `4201028200009261290113185417468510`                      | `RoutingApplicationId` `DestinationZip` `RoutingNumber` `ApplicationIdentifier` `ShipperId` `PackageId` `CheckDigit`      |
 |                  | USPS 91 (IMpb)            | 25–34  | `420221539101026837331000039521` `9361289878700317633795` | `RoutingApplicationId` `DestinationZip` `ApplicationIdentifier` `SCNC` `ServiceType` `ShipperId` `PackageId` `CheckDigit` |
 
 ## JSON Format
+
 - **couriers/*.json** - identifies the standard couriers that might send mail
   - Each courier is defined by json hash with the following keys
 

--- a/couriers/yunexpress.json
+++ b/couriers/yunexpress.json
@@ -1,0 +1,25 @@
+{
+  "name": "YunExpress",
+  "courier_code": "yunexpress",
+  "tracking_numbers": [
+    {
+      "name": "YunExpress",
+      "id": "yunexpress",
+      "tracking_url": "https://www.yuntrack.com/parcelTracking?id=%s",
+      "regex": [
+        "\\s*Y\\s*T\\s*(?<SerialNumber>([0-9]\\s*){16})\\s*"
+      ],
+      "validation": {},
+      "test_numbers": {
+        "valid": [
+          "YT2229521272164446",
+          "YT2229521272164447",
+          " Y T 2 2 2 9 5 2 1 2 7 2 1 6 4 4 4 7 "
+        ],
+        "invalid": [
+          "YT123456789012345"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YunExpress is now a supported courier for package tracking, including recognition of its 18-character serial numbers.

* **Documentation**
  * Updated the supported carriers list to include YunExpress.
  * Added top-level guidance for courier definition JSON files, describing expected fields and examples for defining couriers and tracking number formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->