### PR TITLE
fix(spec/carrier): restore truncated UPS '1Z' tracking identifier regex

### DIFF
--- a/couriers/ups.json
+++ b/couriers/ups.json
@@ -6,7 +6,7 @@
       "name": "UPS",
       "id": "ups",
       "regex": [
-        "\\s*1\\s*Z\\s*(?<SerialNumber>",
+        "\\s*1\\s*Z\\s*(?<SerialNumber>(?:[A-Z0-9]\\s*){16,16})",
         "(?<ShipperId>(?:[A-Z0-9]\\s*){6,6})",
         "(?<ServiceType>(?:[A-Z0-9]\\s*){2,2})",
         "(?<PackageId>(?:[A-Z0-9]\\s*){7,7}))",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined UPS tracking number validation to enforce stricter format requirements for improved accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->